### PR TITLE
Replace Chi logger middleware with logfmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-chi/jwtauth/v5 v5.3.1
 	github.com/go-chi/render v1.0.3
+	github.com/go-kit/log v0.2.1
 	github.com/go-playground/form/v4 v4.2.1
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/joho/godotenv v1.5.1
@@ -46,6 +47,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/inflect v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,10 @@ github.com/go-chi/jwtauth/v5 v5.3.1 h1:1ePWrjVctvp1tyBq5b/2ER8Th/+RbYc7x4qNsc5rh
 github.com/go-chi/jwtauth/v5 v5.3.1/go.mod h1:6Fl2RRmWXs3tJYE1IQGX81FsPoGqDwq9c15j52R5q80=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/server/api.go
+++ b/server/api.go
@@ -40,6 +40,7 @@ func requestLogger(l log.Logger) func(http.Handler) http.Handler {
 				_ = level.Info(l).Log(
 					"method", r.Method,
 					"url", r.URL.String(),
+					"host", r.Host,
 					"status", ww.Status(),
 					"bytes", ww.BytesWritten(),
 					"duration", time.Since(start),

--- a/server/api.go
+++ b/server/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/FyraLabs/subatomic/server/ent"
 	"github.com/FyraLabs/subatomic/server/keyedmutex"
@@ -13,7 +12,6 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/riandyrn/otelchi"
 	httpSwagger "github.com/swaggo/http-swagger"
 
@@ -27,30 +25,6 @@ type apiRouter struct {
 	jwtAuthenticator *jwtauth.JWTAuth
 	repoMutex        *keyedmutex.KeyedMutex
 	logger           log.Logger
-}
-
-// logger backend
-func requestLogger(l log.Logger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-			start := time.Now()
-
-			defer func() {
-				_ = level.Info(l).Log(
-					"method", r.Method,
-					"url", r.URL.String(),
-					"host", r.Host,
-					"status", ww.Status(),
-					"bytes", ww.BytesWritten(),
-					"duration", time.Since(start),
-					"remote", r.RemoteAddr,
-				)
-			}()
-
-			next.ServeHTTP(ww, r)
-		})
-	}
 }
 
 func (router *apiRouter) setup() {

--- a/server/util.go
+++ b/server/util.go
@@ -54,7 +54,7 @@ func recovererMiddleware(l kitlog.Logger) func(http.Handler) http.Handler {
 						"panic", fmt.Sprintf("%v", rvr),
 						"stack", string(debug.Stack()),
 						"method", r.Method,
-						"path", r.URL.Path,
+						"url", r.URL,
 						"remote", r.RemoteAddr,
 					)
 					var err error

--- a/server/util.go
+++ b/server/util.go
@@ -55,6 +55,7 @@ func recovererMiddleware(l kitlog.Logger) func(http.Handler) http.Handler {
 						"stack", string(debug.Stack()),
 						"method", r.Method,
 						"url", r.URL.String(),
+						"host", r.Host,
 						"remote", r.RemoteAddr,
 					)
 					var err error

--- a/server/util.go
+++ b/server/util.go
@@ -54,7 +54,7 @@ func recovererMiddleware(l kitlog.Logger) func(http.Handler) http.Handler {
 						"panic", fmt.Sprintf("%v", rvr),
 						"stack", string(debug.Stack()),
 						"method", r.Method,
-						"url", r.URL,
+						"url", r.URL.String(),
 						"remote", r.RemoteAddr,
 					)
 					var err error


### PR DESCRIPTION
this makes bisecting logs and traces easier by making the logging format more machine-readable, helping with tracing from Grafana Loki and OpenTelemetry

Closes #122 